### PR TITLE
feat: remove time period dropdown and use month by default in edit stream view

### DIFF
--- a/src/components/GranteeFunding.tsx
+++ b/src/components/GranteeFunding.tsx
@@ -122,9 +122,6 @@ export default function GranteeFunding(props: GranteeFundingProps) {
 
   const [step, setStep] = useState<Step>(Step.SELECT_AMOUNT);
   const [amountPerTimeInterval, setAmountPerTimeInterval] = useState("");
-  const [timeInterval, setTimeInterval] = useState<TimeInterval>(
-    TimeInterval.MONTH,
-  );
   const [newFlowRate, setNewFlowRate] = useState("");
   const [underlyingTokenAllowance, setUnderlyingTokenAllowance] = useState("0");
   const [wrapAmount, setWrapAmount] = useState("");
@@ -239,11 +236,11 @@ export default function GranteeFunding(props: GranteeFundingProps) {
   );
 
   const calcLiquidationEstimate = useCallback(
-    (amountPerTimeInterval: string, timeInterval: TimeInterval) => {
+    (amountPerTimeInterval: string) => {
       if (address) {
         const newFlowRate =
           parseEther(amountPerTimeInterval.replace(/,/g, "")) /
-          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[timeInterval]));
+          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[TimeInterval.MONTH]));
         const newFlowRateToFlowState =
           parseEther(supportFlowStateAmount.replace(/,/g, "")) /
           BigInt(
@@ -296,8 +293,8 @@ export default function GranteeFunding(props: GranteeFundingProps) {
   );
 
   const liquidationEstimate = useMemo(
-    () => calcLiquidationEstimate(amountPerTimeInterval, timeInterval),
-    [calcLiquidationEstimate, amountPerTimeInterval, timeInterval],
+    () => calcLiquidationEstimate(amountPerTimeInterval),
+    [calcLiquidationEstimate, amountPerTimeInterval],
   );
 
   const netImpact = useMemo(() => {
@@ -457,7 +454,7 @@ export default function GranteeFunding(props: GranteeFundingProps) {
         formatNumberWithCommas(parseFloat(currentStreamValue)),
       );
     })();
-  }, [address, flowRateToReceiver, timeInterval]);
+  }, [address, flowRateToReceiver]);
 
   useEffect(() => {
     (async () => {
@@ -492,11 +489,11 @@ export default function GranteeFunding(props: GranteeFundingProps) {
       setNewFlowRate(
         (
           parseEther(amountPerTimeInterval.replace(/,/g, "")) /
-          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[timeInterval]))
+          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[TimeInterval.MONTH]))
         ).toString(),
       );
     }
-  }, [areTransactionsLoading, amountPerTimeInterval, timeInterval]);
+  }, [areTransactionsLoading, amountPerTimeInterval]);
 
   useEffect(() => {
     if (areTransactionsLoading) {
@@ -543,7 +540,6 @@ export default function GranteeFunding(props: GranteeFundingProps) {
 
   const updateWrapAmount = (
     amountPerTimeInterval: string,
-    timeInterval: TimeInterval,
     liquidationEstimate: number | null,
   ) => {
     if (amountPerTimeInterval) {
@@ -570,7 +566,7 @@ export default function GranteeFunding(props: GranteeFundingProps) {
       setNewFlowRate(
         (
           parseEther(amountPerTimeInterval.replace(/,/g, "")) /
-          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[timeInterval]))
+          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[TimeInterval.MONTH]))
         ).toString(),
       );
     }
@@ -612,23 +608,10 @@ export default function GranteeFunding(props: GranteeFundingProps) {
               amountPerTimeInterval={amountPerTimeInterval}
               setAmountPerTimeInterval={(amount) => {
                 setAmountPerTimeInterval(amount);
-                updateWrapAmount(
-                  amount,
-                  timeInterval,
-                  calcLiquidationEstimate(amount, timeInterval),
-                );
+                updateWrapAmount(amount, calcLiquidationEstimate(amount));
               }}
               newFlowRate={newFlowRate}
               wrapAmount={wrapAmount}
-              timeInterval={timeInterval}
-              setTimeInterval={(timeInterval) => {
-                setTimeInterval(timeInterval);
-                updateWrapAmount(
-                  amountPerTimeInterval,
-                  timeInterval,
-                  calcLiquidationEstimate(amountPerTimeInterval, timeInterval),
-                );
-              }}
               isFundingMatchingPool={false}
               isEligible={isEligible}
               superTokenBalance={superTokenBalance}
@@ -741,7 +724,6 @@ export default function GranteeFunding(props: GranteeFundingProps) {
               wrapAmount={wrapAmount}
               newFlowRateToFlowState={newFlowRateToFlowState}
               flowRateToFlowState={flowRateToFlowState}
-              timeInterval={timeInterval}
               supportFlowStateAmount={supportFlowStateAmount}
               supportFlowStateTimeInterval={supportFlowStateTimeInterval}
               isFundingMatchingPool={false}

--- a/src/components/MatchingPoolFunding.tsx
+++ b/src/components/MatchingPoolFunding.tsx
@@ -90,9 +90,6 @@ export default function MatchingPoolFunding(props: MatchingPoolFundingProps) {
 
   const [step, setStep] = useState<Step>(Step.SELECT_AMOUNT);
   const [amountPerTimeInterval, setAmountPerTimeInterval] = useState("");
-  const [timeInterval, setTimeInterval] = useState<TimeInterval>(
-    TimeInterval.MONTH,
-  );
   const [newFlowRate, setNewFlowRate] = useState("");
   const [wrapAmount, setWrapAmount] = useState("");
   const [newFlowRateToFlowState, setNewFlowRateToFlowState] = useState("");
@@ -223,11 +220,11 @@ export default function MatchingPoolFunding(props: MatchingPoolFundingProps) {
   );
 
   const calcLiquidationEstimate = useCallback(
-    (amountPerTimeInterval: string, timeInterval: TimeInterval) => {
+    (amountPerTimeInterval: string) => {
       if (address) {
         const newFlowRate =
           parseEther(amountPerTimeInterval.replace(/,/g, "")) /
-          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[timeInterval]));
+          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[TimeInterval.MONTH]));
         const newFlowRateToFlowState =
           parseEther(supportFlowStateAmount.replace(/,/g, "")) /
           BigInt(
@@ -314,8 +311,8 @@ export default function MatchingPoolFunding(props: MatchingPoolFundingProps) {
   }, [network, address]);
 
   const liquidationEstimate = useMemo(
-    () => calcLiquidationEstimate(amountPerTimeInterval, timeInterval),
-    [calcLiquidationEstimate, amountPerTimeInterval, timeInterval],
+    () => calcLiquidationEstimate(amountPerTimeInterval),
+    [calcLiquidationEstimate, amountPerTimeInterval],
   );
 
   const transactions = useMemo(() => {
@@ -445,7 +442,7 @@ export default function MatchingPoolFunding(props: MatchingPoolFundingProps) {
         formatNumberWithCommas(parseFloat(currentStreamValue)),
       );
     })();
-  }, [address, flowRateToReceiver, timeInterval]);
+  }, [address, flowRateToReceiver]);
 
   useEffect(() => {
     (async () => {
@@ -485,11 +482,11 @@ export default function MatchingPoolFunding(props: MatchingPoolFundingProps) {
       setNewFlowRate(
         (
           parseEther(amountPerTimeInterval.replace(/,/g, "")) /
-          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[timeInterval]))
+          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[TimeInterval.MONTH]))
         ).toString(),
       );
     }
-  }, [areTransactionsLoading, amountPerTimeInterval, timeInterval]);
+  }, [areTransactionsLoading, amountPerTimeInterval]);
 
   useEffect(() => {
     if (areTransactionsLoading) {
@@ -556,7 +553,6 @@ export default function MatchingPoolFunding(props: MatchingPoolFundingProps) {
 
   const updateWrapAmount = (
     amountPerTimeInterval: string,
-    timeInterval: TimeInterval,
     liquidationEstimate: number | null,
   ) => {
     if (amountPerTimeInterval) {
@@ -583,7 +579,7 @@ export default function MatchingPoolFunding(props: MatchingPoolFundingProps) {
       setNewFlowRate(
         (
           parseEther(amountPerTimeInterval.replace(/,/g, "")) /
-          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[timeInterval]))
+          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[TimeInterval.MONTH]))
         ).toString(),
       );
     }
@@ -616,23 +612,10 @@ export default function MatchingPoolFunding(props: MatchingPoolFundingProps) {
             amountPerTimeInterval={amountPerTimeInterval}
             setAmountPerTimeInterval={(amount) => {
               setAmountPerTimeInterval(amount);
-              updateWrapAmount(
-                amount,
-                timeInterval,
-                calcLiquidationEstimate(amount, timeInterval),
-              );
+              updateWrapAmount(amount, calcLiquidationEstimate(amount));
             }}
             newFlowRate={newFlowRate}
             wrapAmount={wrapAmount}
-            timeInterval={timeInterval}
-            setTimeInterval={(timeInterval) => {
-              setTimeInterval(timeInterval);
-              updateWrapAmount(
-                amountPerTimeInterval,
-                timeInterval,
-                calcLiquidationEstimate(amountPerTimeInterval, timeInterval),
-              );
-            }}
             isFundingMatchingPool={true}
             superTokenBalance={superTokenBalance}
             hasSufficientBalance={
@@ -706,7 +689,6 @@ export default function MatchingPoolFunding(props: MatchingPoolFundingProps) {
             flowRateToFlowState={flowRateToFlowState}
             newFlowRate={newFlowRate}
             wrapAmount={wrapAmount}
-            timeInterval={timeInterval}
             supportFlowStateAmount={supportFlowStateAmount}
             supportFlowStateTimeInterval={supportFlowStateTimeInterval}
             isFundingMatchingPool={true}

--- a/src/components/checkout/EditStream.tsx
+++ b/src/components/checkout/EditStream.tsx
@@ -1,9 +1,7 @@
 import { useAccount, useSwitchChain } from "wagmi";
-import { parseEther } from "viem";
 import Card from "react-bootstrap/Card";
 import Accordion from "react-bootstrap/Accordion";
 import Stack from "react-bootstrap/Stack";
-import Dropdown from "react-bootstrap/Dropdown";
 import Button from "react-bootstrap/Button";
 import Badge from "react-bootstrap/Badge";
 import Form from "react-bootstrap/Form";
@@ -19,7 +17,6 @@ import {
   fromTimeUnitsToSeconds,
   isNumber,
   formatNumberWithCommas,
-  convertStreamValueToInterval,
 } from "@/lib/utils";
 
 export type EditStreamProps = {
@@ -31,9 +28,7 @@ export type EditStreamProps = {
   amountPerTimeInterval: string;
   newFlowRate: string;
   wrapAmount: string;
-  timeInterval: TimeInterval;
   setAmountPerTimeInterval: (amount: string) => void;
-  setTimeInterval: (timeInterval: TimeInterval) => void;
   isFundingMatchingPool?: boolean;
   isFundingFlowStateCore?: boolean;
   isEligible?: boolean;
@@ -52,8 +47,6 @@ export default function EditStream(props: EditStreamProps) {
     setAmountPerTimeInterval,
     newFlowRate,
     wrapAmount,
-    timeInterval,
-    setTimeInterval,
     isFundingMatchingPool,
     isFundingFlowStateCore,
     isEligible,
@@ -144,9 +137,9 @@ export default function EditStream(props: EditStreamProps) {
         <Stack gap={3}>
           <Card.Text className="small mb-1">
             Flow State donations are implemented as continuous money streams—not
-            one-time or periodic charges. Your support stream will continue at
-            the <strong>rate</strong> you set here until you cancel or modify
-            it.{" "}
+            one-time or periodic charges. Think of them like monthly
+            subscriptions where the total cost is spread across and collected
+            every second in the month.{" "}
             <Card.Link
               href="https://docs.flowstate.network/donors-voters"
               target="_blank"
@@ -176,7 +169,7 @@ export default function EditStream(props: EditStreamProps) {
               {token.name}
             </Badge>
           </Stack>
-          <Stack direction="horizontal" gap={2}>
+          <Stack direction="horizontal" gap={2} className="align-items-stretch">
             <Stack direction="horizontal" className="w-50">
               <Form.Control
                 type="text"
@@ -214,58 +207,9 @@ export default function EditStream(props: EditStreamProps) {
                 </>
               )}
             </Stack>
-            <Dropdown className="w-50">
-              <Dropdown.Toggle
-                variant="blue"
-                className="d-flex justify-content-between align-items-center w-100 bg-white border-0 rounded-3 fs-6"
-              >
-                {timeInterval}
-              </Dropdown.Toggle>
-              <Dropdown.Menu>
-                <Dropdown.Item
-                  onClick={() => {
-                    setAmountPerTimeInterval(
-                      convertStreamValueToInterval(
-                        parseEther(amountPerTimeInterval.replace(/,/g, "")),
-                        timeInterval,
-                        TimeInterval.DAY,
-                      ),
-                    );
-                    setTimeInterval(TimeInterval.DAY);
-                  }}
-                >
-                  {TimeInterval.DAY}
-                </Dropdown.Item>
-                <Dropdown.Item
-                  onClick={() => {
-                    setAmountPerTimeInterval(
-                      convertStreamValueToInterval(
-                        parseEther(amountPerTimeInterval.replace(/,/g, "")),
-                        timeInterval,
-                        TimeInterval.WEEK,
-                      ),
-                    );
-                    setTimeInterval(TimeInterval.WEEK);
-                  }}
-                >
-                  {TimeInterval.WEEK}
-                </Dropdown.Item>
-                <Dropdown.Item
-                  onClick={() => {
-                    setAmountPerTimeInterval(
-                      convertStreamValueToInterval(
-                        parseEther(amountPerTimeInterval.replace(/,/g, "")),
-                        timeInterval,
-                        TimeInterval.MONTH,
-                      ),
-                    );
-                    setTimeInterval(TimeInterval.MONTH);
-                  }}
-                >
-                  {TimeInterval.MONTH}
-                </Dropdown.Item>
-              </Dropdown.Menu>
-            </Dropdown>
+            <Badge className="d-flex align-items-center bg-white w-50 rounded-3 px-3 text-dark fs-6 fw-normal">
+              /month
+            </Badge>
           </Stack>
           {!isFundingMatchingPool &&
             !isFundingFlowStateCore &&

--- a/src/components/checkout/Review.tsx
+++ b/src/components/checkout/Review.tsx
@@ -20,6 +20,7 @@ import {
   formatNumberWithCommas,
   fromTimeUnitsToSeconds,
   TimeInterval,
+  roundWeiAmount,
   convertStreamValueToInterval,
   truncateStr,
 } from "@/lib/utils";
@@ -42,7 +43,6 @@ export type ReviewProps = {
   newFlowRateToFlowState: string;
   flowRateToFlowState: string;
   amountPerTimeInterval: string;
-  timeInterval: TimeInterval;
   supportFlowStateAmount: string;
   supportFlowStateTimeInterval: TimeInterval;
   isFundingMatchingPool?: boolean;
@@ -99,7 +99,6 @@ export default function Review(props: ReviewProps) {
     supportFlowStateAmount,
     supportFlowStateTimeInterval,
     amountPerTimeInterval,
-    timeInterval,
     matchingTokenInfo,
     allocationTokenInfo,
     isFundingMatchingPool,
@@ -380,14 +379,13 @@ export default function Review(props: ReviewProps) {
                 <Badge className="bg-info w-75 ps-2 pe-2 py-2 fs-6 text-start overflow-hidden text-truncate">
                   {formatNumberWithCommas(
                     parseFloat(
-                      convertStreamValueToInterval(
+                      roundWeiAmount(
                         parseEther(
                           areTransactionsLoading && transactionDetailsSnapshot
                             ? transactionDetailsSnapshot.amountPerTimeInterval
                             : amountPerTimeInterval.replace(/,/g, ""),
                         ),
-                        timeInterval,
-                        TimeInterval.MONTH,
+                        4,
                       ),
                     ),
                   )}

--- a/src/pages/core/index.tsx
+++ b/src/pages/core/index.tsx
@@ -96,9 +96,6 @@ dayjs.extend(duration);
 export default function FlowStateCore() {
   const [step, setStep] = useState<Step>(Step.SELECT_AMOUNT);
   const [amountPerTimeInterval, setAmountPerTimeInterval] = useState("");
-  const [timeInterval, setTimeInterval] = useState<TimeInterval>(
-    TimeInterval.MONTH,
-  );
   const [newFlowRate, setNewFlowRate] = useState("");
   const [wrapAmount, setWrapAmount] = useState("");
   const [transactions, setTransactions] = useState<(() => Promise<void>)[]>([]);
@@ -176,11 +173,11 @@ export default function FlowStateCore() {
   }, [address, superfluidQueryRes]);
 
   const calcLiquidationEstimate = useCallback(
-    (amountPerTimeInterval: string, timeInterval: TimeInterval) => {
+    (amountPerTimeInterval: string) => {
       if (address) {
         const newFlowRate =
           parseEther(amountPerTimeInterval.replace(/,/g, "")) /
-          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[timeInterval]));
+          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[TimeInterval.MONTH]));
         const accountFlowRate = userAccountSnapshot?.totalNetFlowRate ?? "0";
 
         if (
@@ -216,8 +213,8 @@ export default function FlowStateCore() {
   );
 
   const liquidationEstimate = useMemo(
-    () => calcLiquidationEstimate(amountPerTimeInterval, timeInterval),
-    [calcLiquidationEstimate, amountPerTimeInterval, timeInterval],
+    () => calcLiquidationEstimate(amountPerTimeInterval),
+    [calcLiquidationEstimate, amountPerTimeInterval],
   );
 
   useEffect(() => {
@@ -283,22 +280,21 @@ export default function FlowStateCore() {
         formatNumberWithCommas(parseFloat(currentStreamValue)),
       );
     })();
-  }, [address, flowRateToReceiver, timeInterval]);
+  }, [address, flowRateToReceiver]);
 
   useEffect(() => {
     if (!areTransactionsLoading && amountPerTimeInterval) {
       setNewFlowRate(
         (
           parseEther(amountPerTimeInterval.replace(/,/g, "")) /
-          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[timeInterval]))
+          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[TimeInterval.MONTH]))
         ).toString(),
       );
     }
-  }, [areTransactionsLoading, amountPerTimeInterval, timeInterval]);
+  }, [areTransactionsLoading, amountPerTimeInterval]);
 
   const updateWrapAmount = (
     amountPerTimeInterval: string,
-    timeInterval: TimeInterval,
     liquidationEstimate: number | null,
   ) => {
     if (amountPerTimeInterval) {
@@ -325,7 +321,7 @@ export default function FlowStateCore() {
       setNewFlowRate(
         (
           parseEther(amountPerTimeInterval.replace(/,/g, "")) /
-          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[timeInterval]))
+          BigInt(fromTimeUnitsToSeconds(1, unitOfTime[TimeInterval.MONTH]))
         ).toString(),
       );
     }
@@ -374,26 +370,10 @@ export default function FlowStateCore() {
                   amountPerTimeInterval={amountPerTimeInterval}
                   setAmountPerTimeInterval={(amount) => {
                     setAmountPerTimeInterval(amount);
-                    updateWrapAmount(
-                      amount,
-                      timeInterval,
-                      calcLiquidationEstimate(amount, timeInterval),
-                    );
+                    updateWrapAmount(amount, calcLiquidationEstimate(amount));
                   }}
                   newFlowRate={newFlowRate}
                   wrapAmount={wrapAmount}
-                  timeInterval={timeInterval}
-                  setTimeInterval={(timeInterval) => {
-                    setTimeInterval(timeInterval);
-                    updateWrapAmount(
-                      amountPerTimeInterval,
-                      timeInterval,
-                      calcLiquidationEstimate(
-                        amountPerTimeInterval,
-                        timeInterval,
-                      ),
-                    );
-                  }}
                   isFundingFlowStateCore={true}
                   superTokenBalance={superTokenBalance}
                   hasSufficientBalance={
@@ -447,7 +427,6 @@ export default function FlowStateCore() {
                   wrapAmount={wrapAmount}
                   newFlowRateToFlowState={"0"}
                   flowRateToFlowState={"0"}
-                  timeInterval={timeInterval}
                   supportFlowStateAmount={"0"}
                   supportFlowStateTimeInterval={TimeInterval.MONTH}
                   isFundingFlowStateCore={true}


### PR DESCRIPTION
Removes the ability to choose the time period based on which the flow rate is calculated and always uses a monthly time period.